### PR TITLE
Avoid data violations with zero-sized allocations

### DIFF
--- a/src/heap.cc
+++ b/src/heap.cc
@@ -33,6 +33,10 @@ namespace tam {
 /// Iterates through all existing free blocks in the heap to try and find one of
 /// the correct size. If none is found, the heap is expanded.
 TamAddr TamEmulator::Allocate(int n) {
+    // if allocating zero bytes, just return 0. otherwise we will have duplicate block addresses
+    if (n == 0)
+        return 0;
+
     // try to find unallocated space inside heap
     for (auto block_iter = this->free_blocks_.begin(),
               iter_end = this->free_blocks_.end();
@@ -66,6 +70,14 @@ TamAddr TamEmulator::Allocate(int n) {
 /// If the block was at the end of the heap then the heap is contracted,
 /// otherwise the freed block is added to the list of available blocks.
 void TamEmulator::Free(TamAddr addr, TamData size) {
+    if (addr == 0) {
+        // address 0 is for zero-sized allocations.
+        if (size != 0)
+            throw RuntimeError(ExceptionKind::kDataAccessViolation,
+                               this->registers_[CP] - 1);
+        return;
+    }
+
     if (addr <= this->registers_[HT])
         throw RuntimeError(ExceptionKind::kDataAccessViolation,
                            this->registers_[CP] - 1);

--- a/test/primitive_heap_tests.cc
+++ b/test/primitive_heap_tests.cc
@@ -52,3 +52,11 @@ TEST_F(HeapTest, FreeMiddleOfHeap) {
     EXPECT_TRUE(this->free_blocks_.count(65533));
     EXPECT_EQ(3, this->free_blocks_[65533]);
 }
+
+TEST_F(HeapTest, HeapAllocateZero) {
+    this->registers_[tam::HT] = 65530;
+    this->allocated_blocks_[65531] = 2;
+    this->allocated_blocks_[65533] = 3;
+    ASSERT_EQ(0, this->Allocate(0));
+    ASSERT_NO_THROW(this->Free(0, 0));
+}


### PR DESCRIPTION
## Summary
Handle zero-sized allocations to avoid returning the same address for multiple allocations.

## Code changes
This adds a special-case for zero-sized allocations to return 0. Currently, zero-sized allocations can cause data violations during freeing due to integer wrapping, and assumptions about each allocations having a unique address.

## Tests
A test has been added to ensure allocating and freeing zero-sized blocks works correctly.

## Other comments
An alternative fix could be to set the size to 1 if it's 0 in allocate/delete.